### PR TITLE
Revised the way to set parameters for the NewsAPI

### DIFF
--- a/newsParams.json
+++ b/newsParams.json
@@ -1,0 +1,23 @@
+{
+  "title": "newsParams",
+  "description": "Configure NewsAPI query parameters. The API key should be set in code, not in this file.",
+  "reference": "https://newsapi.org/docs/endpoints/everything",
+  "params": [
+    {
+      "key": "q",
+      "value": "IT"
+    },
+    {
+      "key": "sortBy",
+      "value": "publishedAt"
+    },
+    {
+      "key": "pageSize",
+      "value": "10"
+    }, 
+    {
+      "key": "language",
+      "value": "jp"
+    } 
+  ]
+}

--- a/src/main.go
+++ b/src/main.go
@@ -38,6 +38,10 @@ func handlerWithDeps(ctx context.Context, event events.APIGatewayProxyRequest, n
 
 	// environment variable
 
+	// NewsAPI
+	NEWS_API_BASE_URL := os.Getenv("NEWS_API_BASE_URL")
+	NEWS_API_KEY := os.Getenv("NEWS_API_KEY")
+
 	// GoogleCalendar
 	// AWS_SECRET_MANAGER_NAME := os.Getenv("AWS_SECRET_MANAGER_NAME")
 	// AWS_SECRET_MANAGER_REGION := os.Getenv("AWS_SECRET_MANAGER_REGION")
@@ -55,16 +59,17 @@ func handlerWithDeps(ctx context.Context, event events.APIGatewayProxyRequest, n
 	// schedule := getCalendar(credential)
 	// fmt.Println("schedule : ", schedule)
 
-	newsAPIParams := NewsAPIParams{
-		BaseURL:  os.Getenv("NEWS_API_BASE_URL"),
-		Query:    os.Getenv("NEWS_API_QUERY"),
-		SortBy:   os.Getenv("NEWS_API_SORT_BY"),
-		PageSize: os.Getenv("NEWS_API_PAGE_SIZE"),
-		Language: os.Getenv("NEWS_API_LANGUAGE"),
-		APIKey:   os.Getenv("NEWS_API_KEY"),
-	}
+	//	newsAPIParams := NewsAPIParams{
+	//		BaseURL:  os.Getenv("NEWS_API_BASE_URL"),
+	//		Query:    os.Getenv("NEWS_API_QUERY"),
+	//		SortBy:   os.Getenv("NEWS_API_SORT_BY"),
+	//		PageSize: os.Getenv("NEWS_API_PAGE_SIZE"),
+	//		Language: os.Getenv("NEWS_API_LANGUAGE"),
+	//		APIKey:   os.Getenv("NEWS_API_KEY"),
+	//	}
 
-	newsAPIURL, err := BuildNewsAPIURL(newsAPIParams)
+	// newsAPIURL, err := BuildNewsAPIURL(newsAPIParams)
+	newsAPIURL, err := BuildNewsAPIURL("../newsParams.json", NEWS_API_BASE_URL, NEWS_API_KEY)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/src/url.go
+++ b/src/url.go
@@ -1,31 +1,63 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/url"
+	"os"
 )
 
-type NewsAPIParams struct {
-	BaseURL   string
-	Query     string
-	SortBy    string
-	PageSize  string
-	Language  string
-	APIKey    string
+type Param struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
 }
 
-func BuildNewsAPIURL(p NewsAPIParams) (string, error) {
-	u, err := url.Parse(p.BaseURL)
+type NewsParamsFile struct {
+	Title       string  `json:"title"`
+	Description string  `json:"description"`
+	Reference   string  `json:"reference"`
+	Params      []Param `json:"params"`
+}
+
+// fileName: path to newsParams.json
+// baseURL: NewsAPI endpoint base URL (e.g. https://newsapi.org/v2/everything)
+// apiKey: API key string (should not be in json file)
+func BuildNewsAPIURL(fileName, baseURL, apiKey string) (string, error) {
+	file, err := os.Open(fileName)
 	if err != nil {
-		fmt.Println(err)
-		return "", err
+		return "", fmt.Errorf("failed to open params file: %w", err)
+	}
+	defer file.Close()
+
+	var paramsFile NewsParamsFile
+	decoder := json.NewDecoder(file)
+	if err := decoder.Decode(&paramsFile); err != nil {
+		return "", fmt.Errorf("failed to decode params json: %w", err)
+	}
+
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid baseURL: %w", err)
 	}
 	q := u.Query()
-	q.Set("q", p.Query)
-	q.Set("sortBy", p.SortBy)
-	q.Set("pageSize", p.PageSize)
-	q.Set("language", p.Language)
-	q.Set("apiKey", p.APIKey)
+	for _, p := range paramsFile.Params {
+		q.Set(p.Key, p.Value)
+	}
+	q.Set("apiKey", apiKey)
 	u.RawQuery = q.Encode()
 	return u.String(), nil
 }
+
+//	u, err := url.Parse(p.BaseURL)
+//	if err != nil {
+//		fmt.Println(err)
+//		return "", err
+//	}
+//	q := u.Query()
+//	q.Set("q", p.Query)
+//	q.Set("sortBy", p.SortBy)
+//	q.Set("pageSize", p.PageSize)
+//	q.Set("language", p.Language)
+//	q.Set("apiKey", p.APIKey)
+//	u.RawQuery = q.Encode()
+//	return u.String(), nil

--- a/src/url_test.go
+++ b/src/url_test.go
@@ -1,23 +1,43 @@
+//go:build testonly
+// +build testonly
+
 package main
 
 import (
+	"net/url"
 	"testing"
 )
 
 func TestBuildNewsAPIURL_Success(t *testing.T) {
-	newsAPIParams := NewsAPIParams{
-		BaseURL:  "http://test.com",
-		Query:    "query",
-		SortBy:   "sortBy",
-		PageSize: "pageSize",
-		Language: "language",
-		APIKey:   "apiKey",
-	}
-	newsAPIURL, err := BuildNewsAPIURL(newsAPIParams)
+	fileName := "../testdate/newsParams-success.json"
+	baseURL := "http://test.com"
+	apiKey := "test"
+	newsAPIURL, err := BuildNewsAPIURL(fileName, baseURL, apiKey)
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
 	}
-	if newsAPIURL != "http://test.com?apiKey=apiKey&language=language&pageSize=pageSize&q=query&sortBy=sortBy" {
-		t.Errorf("built URL mismatch. \r\nbuilt URL : %v", newsAPIURL)
+
+	u, err := url.Parse(newsAPIURL)
+	if err != nil {
+		t.Fatalf("failed to parse built URL: %v", err)
+	}
+	q := u.Query()
+	if q.Get("q") != "query" {
+		t.Errorf("expected q=query, got %v", q.Get("q"))
+	}
+	if q.Get("sortBy") != "sortBy" {
+		t.Errorf("expected sortBy=sortBy, got %v", q.Get("sortBy"))
+	}
+	if q.Get("pageSize") != "pageSize" {
+		t.Errorf("expected pageSize=pageSize, got %v", q.Get("pageSize"))
+	}
+	if q.Get("language") != "language" {
+		t.Errorf("expected language=language, got %v", q.Get("language"))
+	}
+	if q.Get("apiKey") != "apiKey" {
+		t.Errorf("expected apiKey=apiKey, got %v", q.Get("apiKey"))
+	}
+	if u.Scheme != "http" || u.Host != "test.com" {
+		t.Errorf("unexpected base url: %v", newsAPIURL)
 	}
 }


### PR DESCRIPTION
・before parameters of NewsAPI received from .env, now from newsAPIParams.json.
This change improves maintainability and makes future changes easier.